### PR TITLE
Minor fix in disp estimation slicing with pad in `base_trainer.py`

### DIFF
--- a/openstereo/base_trainer.py
+++ b/openstereo/base_trainer.py
@@ -339,7 +339,11 @@ class BaseTrainer:
             # crop padding
             if 'pad' in ipts:
                 pad_top, pad_right, _, _ = ipts['pad']
-                disp_est = disp_est[:, pad_top:, :-pad_right]
+                # tensor[:0] is equivalent to remove this dimension
+                if pad_right == 0:
+                    disp_est = disp_est[:, pad_top:, :]
+                else:
+                    disp_est = disp_est[:, pad_top:, :-pad_right]
             # save to file
             img = disp_est.squeeze(0).cpu().numpy()
             img = (img * 256).astype('uint16')


### PR DESCRIPTION
Fix the tensor slicing error when the `pad_right=0` which removes the last dimension.