### PR TITLE
feat: enable CUDA Graph in TensorRT execution and improve README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -65,6 +65,11 @@ Or build using the downloaded TensorRT tar package:
 cmake -DTENSORRT_ROOT=<path_to_tensorrt> .. && make
 ```
 
+Remember specify your CUDA architecture
+```bash
+cmake -DTENSORRT_ROOT=<path_to_tensorrt> -DCMAKE_CUDA_ARCHITECTURES=<your_cuda_architecture> .. && make
+```
+
 Then, you can perform inference with the following command:
 
 ```bash

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -64,6 +64,11 @@ cmake .. && make
 cmake -DTENSORRT_ROOT=<path_to_tensorrt> .. && make
 ```
 
+指定你的cuda architecture
+```bash
+cmake -DTENSORRT_ROOT=<path_to_tensorrt> -DCMAKE_CUDA_ARCHITECTURES=<your_cuda_architecture> .. && make
+```
+
 然后，可以使用以下命令进行推理：
 
 ```bash

--- a/deploy/cpp/include/inference.h
+++ b/deploy/cpp/include/inference.h
@@ -38,8 +38,13 @@ private:
     nvinfer1::IRuntime* runtime_;
     nvinfer1::ICudaEngine* engine_;
     nvinfer1::IExecutionContext* context_;
+    // employed cudaGraph for better performance
+    cudaGraph_t graph_ = nullptr;
+    cudaGraphExec_t instance_ = nullptr;
 
     // void* buffers_[2];
+    nvinfer1::Dims dims;
+    nvinfer1::DataType dtype;
     std::vector<void*> buffers_;
     cudaStream_t stream_;
     std::vector<char> engine_data_;

--- a/deploy/cpp/main.cpp
+++ b/deploy/cpp/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
     auto preprocess_result = transform(sample);
 
     auto end_preprocess = std::chrono::high_resolution_clock::now();
-    auto duration_preprocess = std::chrono::duration_cast<std::chrono::milliseconds>(end_preprocess - start_preprocess);
+    std::chrono::duration<double, std::milli> duration_preprocess = end_preprocess - start_preprocess;
 
     // Try run and warm up engine
     try {
@@ -133,9 +133,10 @@ int main(int argc, char* argv[]) {
     std::unordered_map<std::string, cv::Mat> output = engine.run(preprocess_result);
 
     auto end_inference = std::chrono::high_resolution_clock::now();
-    auto duration_inference = std::chrono::duration_cast<std::chrono::milliseconds>(end_inference - start_inference);
+    std::chrono::duration<double, std::milli> duration_inference = end_inference - start_inference;
 
     std::cout << "==================== TimeInfo ====================" << std::endl
+              <<  std::fixed << std::setprecision(4)
               << "preprocess: " << duration_preprocess.count() << " ms" << std::endl
               << "inference : " << duration_inference.count() << " ms" << std::endl;
 


### PR DESCRIPTION
### Summary
This PR integrates CUDA Graph into TensorRT execution to reduce kernel launch overhead and improve inference performance. Additionally, the README has been updated.

### Changes
- Enable CUDA Graph to capture and replay TensorRT inference execution
- Optimize execution flow to reduce per-inference launch latency
- Improve README

### Performance Impact
- CUDA Graph reduces CPU overhead and improves overall inference speed by ~25-30% on tested workloads, LightStereo-S-KITTI.

### Testing
- Verified on an NVIDIA 4080 Super with TensorRT 10.9.
- Ensured correctness by comparing outputs before and after CUDA Graph integration.